### PR TITLE
Fixed "Alt Gr" key

### DIFF
--- a/scripts/ImGui/ImGui.gml
+++ b/scripts/ImGui/ImGui.gml
@@ -3960,7 +3960,7 @@ function ImGui() constructor {
 			}
 			__imgui_key(ImGuiKey.ImGuiMod_Ctrl, keyboard_check_direct(vk_lcontrol));
 			__imgui_key(ImGuiKey.ImGuiMod_Shift, keyboard_check_direct(vk_lshift));
-			__imgui_key(ImGuiKey.ImGuiMod_Alt, keyboard_check_direct(vk_lalt));
+			__imgui_key(ImGuiKey.ImGuiMod_Alt, keyboard_check_direct(vk_lalt) || keyboard_check_direct(vk_ralt));
 			if (__imgui_want_text_input(undefined)) {
 				if (!__InputRequested) {
 					__InputRequested = true;


### PR DESCRIPTION
In some languages, this key is used to enter characters such as "@", "\", "|", etc. It is similar to pressing "left ctrl + left alt".

In the input text, this key was not working and adding the double comparison makes it work correctly.